### PR TITLE
dont throw on 404

### DIFF
--- a/lib/ApiBaseHTTP.js
+++ b/lib/ApiBaseHTTP.js
@@ -74,7 +74,7 @@
           var arity, _ref;
           if (err) {
             debug('an error has occured', err);
-            if ((400 <= (_ref = err.statusCode) && _ref <= 499)) {
+            if ((400 <= (_ref = err.statusCode) && _ref <= 499 && _ref !== 404)) {
               throw "Authorisation error. " + err.statusCode + ". Check your key.";
             }
           }


### PR DESCRIPTION
Currently the application throws an error on 404, which is not an authorization failure. This breaks the usage when accessing a not available content.

Also it would be preferable to use a callback with err as first parameter instead of throwing. This throw really destroys the control flow from applications trying to use it.