### PR TITLE
Use headers for PRIVATE-TOKEN

### DIFF
--- a/lib/ApiBaseHTTP.js
+++ b/lib/ApiBaseHTTP.js
@@ -64,7 +64,9 @@
       if (opts.__query == null) {
         opts.__query = {};
       }
-      opts.__query.private_token = this.options.token;
+      opts.headers = {
+        'PRIVATE-TOKEN': this.options.token
+      };
       return opts;
     };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitlab",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "GitLab API Nodejs library.",
   "main": "lib/index.js",
   "directories": {
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "debug": "*",
-    "slumber": ">=0.5.0"
+    "slumber": ">=0.7.0"
   },
   "devDependencies": {
     "coffee-script": ">=1.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitlab",
-  "version": "1.4.1",
+  "version": "1.4.0",
   "description": "GitLab API Nodejs library.",
   "main": "lib/index.js",
   "directories": {

--- a/src/ApiBaseHTTP.coffee
+++ b/src/ApiBaseHTTP.coffee
@@ -32,7 +32,7 @@ class module.exports.ApiBaseHTTP extends ApiBase
 
   prepare_opts: (opts) =>
     opts.__query ?= {}
-    opts.__query.private_token = @options.token
+    opts.headers = { 'PRIVATE-TOKEN': @options.token }
     return opts
 
   fn_wrapper: (fn) =>


### PR DESCRIPTION
Pull request for #91 to use headers over querystring for the private token.