### PR TITLE
Fixed loading all users and groups by getting all pages.

### DIFF
--- a/lib/Models/Groups.js
+++ b/lib/Models/Groups.js
@@ -71,13 +71,7 @@
           }
         };
       })(this);
-      return this.get("groups", params, (function(_this) {
-        return function(data) {
-          if (fn) {
-            return fn(data);
-          }
-        };
-      })(this));
+      return this.get("groups", params, cb);
     };
 
     Groups.prototype.show = function(groupId, fn) {

--- a/lib/Models/Users.js
+++ b/lib/Models/Users.js
@@ -58,13 +58,7 @@
           }
         };
       })(this);
-      return this.get("users", params, (function(_this) {
-        return function(data) {
-          if (fn) {
-            return fn(data);
-          }
-        };
-      })(this));
+      return this.get("users", params, cb);
     };
 
     Users.prototype.current = function(fn) {

--- a/src/Models/Groups.coffee
+++ b/src/Models/Groups.coffee
@@ -31,7 +31,7 @@ class Groups extends BaseModel
         data = data.concat(retData)
         return fn data if fn
 
-    @get "groups", params, (data) => fn data if fn
+    @get "groups", params, cb
 
   show: (groupId, fn = null) =>
     @debug "Groups::show()"

--- a/src/Models/Users.coffee
+++ b/src/Models/Users.coffee
@@ -23,7 +23,7 @@ class Users extends BaseModel
         data = data.concat(retData)
         return fn data if fn
 
-    @get "users", params, (data) => fn data if fn
+    @get "users", params, cb
 
   current: (fn = null) =>
     @debug "Users::current()"


### PR DESCRIPTION
This should allow all users and groups to be loaded without requesting each page individually.   

I think the callback functions were added in a previous commit but, unlike the projects call, they were never setup to be called.