### PR TITLE
Fix undefined assigneeId in merge request. See issue #111.

### DIFF
--- a/lib/Models/ProjectMergeRequests.js
+++ b/lib/Models/ProjectMergeRequests.js
@@ -71,9 +71,11 @@
         id: Utils.parseProjectId(projectId),
         source_branch: sourceBranch,
         target_branch: targetBranch,
-        assignee_id: parseInt(assigneeId),
         title: title
       };
+      if (assigneeId !== void 0) {
+        params.assigneeId = parseInt(assigneeId);
+      }
       return this.post("projects/" + (Utils.parseProjectId(projectId)) + "/merge_requests", params, (function(_this) {
         return function(data) {
           if (fn) {

--- a/src/Models/ProjectMergeRequests.coffee
+++ b/src/Models/ProjectMergeRequests.coffee
@@ -23,8 +23,8 @@ class ProjectMergeRequests extends BaseModel
       id:            Utils.parseProjectId projectId
       source_branch: sourceBranch
       target_branch: targetBranch
-      assignee_id:   parseInt assigneeId
       title:         title
+    params.assigneeId = parseInt assigneeId unless assigneeId is undefined
     @post "projects/#{Utils.parseProjectId projectId}/merge_requests", params, (data) => fn data if fn
 
   update: (projectId, mergerequestId, params, fn = null) =>


### PR DESCRIPTION
According to Gitlab API doc:

Parameters:

 - id (required) - The ID of a project
 - source_branch (required) - The source branch
 - target_branch (required) - The target branch
 - **assignee_id (optional) - Assignee user ID**
 - title (required) - Title of MR
 - description (optional) - Description of MR
 - target_project_id (optional) - The target project (numeric id)
 - labels (optional) - Labels for MR as a comma-separated list

**assignee_id** should be optional. But in current implementation, `assignee_id:   parseInt assigneeId`. Pass an undefined assigneeId into `parseInt` returns NaN, which would be a wrong parameter to call the API.

See issue #111 .
