### PR TITLE
Add possibility to showFile by sha id

### DIFF
--- a/lib/Models/ProjectRepository.js
+++ b/lib/Models/ProjectRepository.js
@@ -215,6 +215,14 @@
             }
           };
         })(this));
+      } else if (params.file_path && params.file_id) {
+        return this.get(("projects/" + (Utils.parseProjectId(params.projectId)) + "/repository/raw_blobs/") + params.file_id, params, (function(_this) {
+          return function(data) {
+            if (fn) {
+              return fn(data);
+            }
+          };
+        })(this));
       }
     };
 

--- a/src/Models/ProjectRepository.coffee
+++ b/src/Models/ProjectRepository.coffee
@@ -65,6 +65,8 @@ class ProjectRepository extends BaseModel
     @debug "Projects::showFile()", params
     if params.file_path and params.ref
       @get "projects/#{Utils.parseProjectId params.projectId}/repository/files", params, (data) => fn data if fn
+    else if params.file_path and params.file_id
+      @get "projects/#{Utils.parseProjectId params.projectId}/repository/raw_blobs/" + params.file_id, params, (data) => fn data if fn
 
   createFile: (params = {}, fn = null) =>
     @debug "Projects::createFile()", params


### PR DESCRIPTION
For unknown reason (can't find out why), I can't GET on repository/files on my Legacy Corporate Gitlab v6.5.1 : 

HTTP/1.1 405 Method Not Allowed
Status: 405 Method Not Allowed
Allow: OPTIONS, POST, PUT, DELETE

So I wrote this patch. I will not mind if you never merge it, maybe  it's a wrong idea.

Cyril