### PR TITLE
Add oauth_token option to authenticate connection

### DIFF
--- a/lib/ApiBaseHTTP.js
+++ b/lib/ApiBaseHTTP.js
@@ -37,8 +37,8 @@
       if (!this.options.url) {
         throw "`url` is mandatory";
       }
-      if (!this.options.token) {
-        throw "`private_token` is mandatory";
+      if (!(this.options.token || this.options.oauth_token)) {
+        throw "`private_token` or `oauth_token` is mandatory";
       }
       if ((base1 = this.options).slumber == null) {
         base1.slumber = {};
@@ -64,9 +64,15 @@
       if (opts.__query == null) {
         opts.__query = {};
       }
-      opts.headers = {
-        'PRIVATE-TOKEN': this.options.token
-      };
+      if (this.options.token) {
+        opts.headers = {
+          'PRIVATE-TOKEN': this.options.token
+        };
+      } else {
+        opts.headers = {
+          'Authorization': 'Bearer ' + this.options.oauth_token
+        };
+      }
       return opts;
     };
 

--- a/src/ApiBaseHTTP.coffee
+++ b/src/ApiBaseHTTP.coffee
@@ -12,8 +12,8 @@ class module.exports.ApiBaseHTTP extends ApiBase
     unless @options.url
       throw "`url` is mandatory"
 
-    unless @options.token
-      throw "`private_token` is mandatory"
+    unless @options.token or @options.oauth_token
+      throw "`private_token` or `oauth_token` is mandatory"
 
     @options.slumber ?= {}
     @options.slumber.append_slash ?= false
@@ -32,7 +32,10 @@ class module.exports.ApiBaseHTTP extends ApiBase
 
   prepare_opts: (opts) =>
     opts.__query ?= {}
-    opts.headers = { 'PRIVATE-TOKEN': @options.token }
+    if @options.token
+      opts.headers = { 'PRIVATE-TOKEN': @options.token }
+    else
+      opts.headers = { 'Authorization': 'Bearer ' + @options.oauth_token }
     return opts
 
   fn_wrapper: (fn) =>


### PR DESCRIPTION
The GitLab spec allows authentication with the private_token or oauth bearer
token. This modification accepts the oauth_token parameter for connection,
and puts the token into the headers if it is supplied.

Docs:
https://gitlab.eecs.umich.edu/help/api/README.md#authentication-with-oauth2-token