### PR TITLE
Extend groups

### DIFF
--- a/lib/ApiBaseHTTP.js
+++ b/lib/ApiBaseHTTP.js
@@ -37,8 +37,8 @@
       if (!this.options.url) {
         throw "`url` is mandatory";
       }
-      if (!this.options.token) {
-        throw "`private_token` is mandatory";
+      if (!(this.options.token || this.options.oauth_token)) {
+        throw "`private_token` or `oauth_token` is mandatory";
       }
       if ((base1 = this.options).slumber == null) {
         base1.slumber = {};
@@ -64,9 +64,15 @@
       if (opts.__query == null) {
         opts.__query = {};
       }
-      opts.headers = {
-        'PRIVATE-TOKEN': this.options.token
-      };
+      if (this.options.token) {
+        opts.headers = {
+          'PRIVATE-TOKEN': this.options.token
+        };
+      } else {
+        opts.headers = {
+          'Authorization': 'Bearer ' + this.options.oauth_token
+        };
+      }
       return opts;
     };
 

--- a/lib/Models/Groups.js
+++ b/lib/Models/Groups.js
@@ -11,8 +11,11 @@
 
     function Groups() {
       this.search = bind(this.search, this);
+      this.deleteGroup = bind(this.deleteGroup, this);
       this.addProject = bind(this.addProject, this);
       this.create = bind(this.create, this);
+      this.removeMember = bind(this.removeMember, this);
+      this.editMember = bind(this.editMember, this);
       this.addMember = bind(this.addMember, this);
       this.listMembers = bind(this.listMembers, this);
       this.listProjects = bind(this.listProjects, this);
@@ -149,6 +152,50 @@
       });
     };
 
+    Groups.prototype.editMember = function(groupId, userId, accessLevel, fn) {
+      var checkAccessLevel, params;
+      if (fn == null) {
+        fn = null;
+      }
+      this.debug("Groups::editMember(" + groupId + ", " + userId + ", " + accessLevel + ")");
+      checkAccessLevel = (function(_this) {
+        return function() {
+          var access_level, k, ref;
+          ref = _this.access_levels;
+          for (k in ref) {
+            access_level = ref[k];
+            if (accessLevel === access_level) {
+              return true;
+            }
+          }
+          return false;
+        };
+      })(this);
+      if (!checkAccessLevel()) {
+        throw "`accessLevel` must be one of " + (JSON.stringify(this.access_levels));
+      }
+      params = {
+        access_level: accessLevel
+      };
+      return this.put("groups/" + (parseInt(groupId)) + "/members/" + (parseInt(userId)), params, function(data) {
+        if (fn) {
+          return fn(data);
+        }
+      });
+    };
+
+    Groups.prototype.removeMember = function(groupId, userId, fn) {
+      if (fn == null) {
+        fn = null;
+      }
+      this.debug("Groups::removeMember(" + groupId + ", " + userId + ")");
+      return this["delete"]("groups/" + (parseInt(groupId)) + "/members/" + (parseInt(userId)), function(data) {
+        if (fn) {
+          return fn(data);
+        }
+      });
+    };
+
     Groups.prototype.create = function(params, fn) {
       if (params == null) {
         params = {};
@@ -170,6 +217,18 @@
       }
       this.debug("Groups::addProject(" + groupId + ", " + projectId + ")");
       return this.post("groups/" + (parseInt(groupId)) + "/projects/" + (parseInt(projectId)), null, function(data) {
+        if (fn) {
+          return fn(data);
+        }
+      });
+    };
+
+    Groups.prototype.deleteGroup = function(groupId, fn) {
+      if (fn == null) {
+        fn = null;
+      }
+      this.debug("Groups::delete(" + groupId + ")");
+      return this["delete"]("groups/" + (parseInt(groupId)), function(data) {
         if (fn) {
           return fn(data);
         }

--- a/src/ApiBaseHTTP.coffee
+++ b/src/ApiBaseHTTP.coffee
@@ -12,8 +12,8 @@ class module.exports.ApiBaseHTTP extends ApiBase
     unless @options.url
       throw "`url` is mandatory"
 
-    unless @options.token
-      throw "`private_token` is mandatory"
+    unless @options.token or @options.oauth_token
+      throw "`private_token` or `oauth_token` is mandatory"
 
     @options.slumber ?= {}
     @options.slumber.append_slash ?= false
@@ -32,7 +32,10 @@ class module.exports.ApiBaseHTTP extends ApiBase
 
   prepare_opts: (opts) =>
     opts.__query ?= {}
-    opts.headers = { 'PRIVATE-TOKEN': @options.token }
+    if @options.token
+      opts.headers = { 'PRIVATE-TOKEN': @options.token }
+    else
+      opts.headers = { 'Authorization': 'Bearer ' + @options.oauth_token }
     return opts
 
   fn_wrapper: (fn) =>

--- a/src/Models/Groups.coffee
+++ b/src/Models/Groups.coffee
@@ -62,6 +62,26 @@ class Groups extends BaseModel
 
     @post "groups/#{parseInt groupId}/members", params, (data) -> fn data if fn
 
+  editMember: (groupId, userId, accessLevel, fn = null) =>
+    @debug "Groups::editMember(#{groupId}, #{userId}, #{accessLevel})"
+
+    checkAccessLevel = =>
+      for k, access_level of @access_levels
+        return true if accessLevel == access_level
+      false
+
+    unless do checkAccessLevel
+      throw "`accessLevel` must be one of #{JSON.stringify @access_levels}"
+
+    params =
+      access_level: accessLevel
+
+    @put "groups/#{parseInt groupId}/members/#{parseInt userId}", params, (data) -> fn data if fn
+
+  removeMember: (groupId, userId, fn = null) =>
+    @debug "Groups::removeMember(#{groupId}, #{userId})"
+    @delete "groups/#{parseInt groupId}/members/#{parseInt userId}", (data) -> fn data if fn
+
   create: (params = {}, fn = null) =>
     @debug "Groups::create()"
     @post "groups", params, (data) -> fn data if fn
@@ -69,6 +89,10 @@ class Groups extends BaseModel
   addProject: (groupId, projectId, fn = null) =>
     @debug "Groups::addProject(#{groupId}, #{projectId})"
     @post "groups/#{parseInt groupId}/projects/#{parseInt projectId}", null, (data) -> fn data if fn
+
+  deleteGroup: (groupId, fn = null) =>
+    @debug "Groups::delete(#{groupId})"
+    @delete "groups/#{parseInt groupId}", (data) -> fn data if fn
 
   search: (nameOrPath, fn = null) =>
     @debug "Groups::search(#{nameOrPath})"


### PR DESCRIPTION
The GitLab Groups API is currently only partially implemented. This patch adds the remaining methods.