### PR TITLE
Pass an optional params object to the list builds API.

### DIFF
--- a/lib/Models/ProjectBuilds.js
+++ b/lib/Models/ProjectBuilds.js
@@ -18,12 +18,25 @@
       return ProjectBuilds.__super__.constructor.apply(this, arguments);
     }
 
-    ProjectBuilds.prototype.listBuilds = function(projectId, fn) {
+    ProjectBuilds.prototype.listBuilds = function(projectId, params, fn) {
+      if (params == null) {
+        params = {};
+      }
       if (fn == null) {
         fn = null;
       }
+      if ('function' === typeof params) {
+        fn = params;
+        params = {};
+      }
+      if (params.page == null) {
+        params.page = 1;
+      }
+      if (params.per_page == null) {
+        params.per_page = 100;
+      }
       this.debug("Projects::listBuilds()");
-      return this.get("projects/" + (Utils.parseProjectId(projectId)) + "/builds", (function(_this) {
+      return this.get("projects/" + (Utils.parseProjectId(projectId)) + "/builds", params, (function(_this) {
         return function(data) {
           if (fn) {
             return fn(data);

--- a/src/Models/ProjectBuilds.coffee
+++ b/src/Models/ProjectBuilds.coffee
@@ -4,9 +4,16 @@ Utils = require '../Utils'
 class ProjectBuilds extends BaseModel
 
   # === Builds
-  listBuilds: (projectId, fn = null) =>
+  listBuilds: (projectId, params={}, fn = null) =>
+    if 'function' is typeof params
+      fn = params
+      params={}
+
+    params.page ?= 1
+    params.per_page ?= 100
+
     @debug "Projects::listBuilds()"
-    @get "projects/#{Utils.parseProjectId projectId}/builds", (data) => fn data if fn
+    @get "projects/#{Utils.parseProjectId projectId}/builds", params, (data) => fn data if fn
 
   showBuild: (projectId, buildId, fn = null) =>
     @debug "Projects::build()"


### PR DESCRIPTION
This allows providing a scope value to limit the number of returned builds. See
API documentation at http://docs.gitlab.com/ee/api/builds.html.