### PR TITLE
fix double parsing of response.body

### DIFF
--- a/src/ApiBaseHTTP.coffee
+++ b/src/ApiBaseHTTP.coffee
@@ -43,8 +43,12 @@ class module.exports.ApiBaseHTTP extends ApiBase
       arity = fn.length
       switch arity
         when 1 then fn ret
-        when 2 then fn err, ret || JSON.parse(response.body).message
-        when 3 then fn err, response, ret
+        when 2 
+          if typeof response.body == 'object'
+            fn err, ret || response.body.message
+          else
+            fn err, ret || JSON.parse(response.body).message
+        when 3 then fn err, response, ret	
 
   get: (path, query={}, fn=null) =>
     if 'function' is typeof query

--- a/src/ApiBaseHTTP.coffee
+++ b/src/ApiBaseHTTP.coffee
@@ -43,12 +43,12 @@ class module.exports.ApiBaseHTTP extends ApiBase
       arity = fn.length
       switch arity
         when 1 then fn ret
-        when 2 
+        when 2
           if typeof response.body == 'object'
             fn err, ret || response.body.message
           else
             fn err, ret || JSON.parse(response.body).message
-        when 3 then fn err, response, ret	
+        when 3 then fn err, response, ret
 
   get: (path, query={}, fn=null) =>
     if 'function' is typeof query


### PR DESCRIPTION
when the response body is already an object don't try to parse it again
should be fixing #149 

This is of interest for me because I have a project which fails because of that problem.
https://github.com/piceaTech/node-gitlab-2-github/issues/16