### PR TITLE
Fixed API doc, merge request acceptance and protect branch with parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ node-gitlab
 --
 
 [GitLab](https://github.com/gitlabhq/gitlabhq) API Nodejs library.
-It wraps the HTTP api library described [here](https://github.com/gitlabhq/gitlabhq/tree/master/doc/api).
+It wraps the HTTP api library described [here](https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/README.md).
 
 Maintained by [Manfred Touron](https://github.com/moul) and [Dave Irvine](https://github.com/dave-irvine)
 

--- a/lib/Models/ProjectMergeRequests.js
+++ b/lib/Models/ProjectMergeRequests.js
@@ -12,6 +12,7 @@
     extend(ProjectMergeRequests, superClass);
 
     function ProjectMergeRequests() {
+      this.merge = bind(this.merge, this);
       this.comment = bind(this.comment, this);
       this.update = bind(this.update, this);
       this.add = bind(this.add, this);
@@ -113,6 +114,22 @@
         note: note
       };
       return this.post("projects/" + (Utils.parseProjectId(projectId)) + "/merge_request/" + (parseInt(mergerequestId)) + "/comments", params, (function(_this) {
+        return function(data) {
+          if (fn) {
+            return fn(data);
+          }
+        };
+      })(this));
+    };
+
+    ProjectMergeRequests.prototype.merge = function(projectId, mergerequestId, params, fn) {
+      if (fn == null) {
+        fn = null;
+      }
+      this.debug("Projects::acceptMergeRequest()");
+      params.id = Utils.parseProjectId(projectId);
+      params.merge_request_id = parseInt(mergerequestId);
+      return this.put("projects/" + (Utils.parseProjectId(projectId)) + "/merge_request/" + (parseInt(mergerequestId)) + "/merge", params, (function(_this) {
         return function(data) {
           if (fn) {
             return fn(data);

--- a/lib/Models/ProjectRepository.js
+++ b/lib/Models/ProjectRepository.js
@@ -61,12 +61,15 @@
       })(this));
     };
 
-    ProjectRepository.prototype.protectBranch = function(projectId, branchId, fn) {
+    ProjectRepository.prototype.protectBranch = function(projectId, branchId, params, fn) {
+      if (params == null) {
+        params = {};
+      }
       if (fn == null) {
         fn = null;
       }
       this.debug("Projects::protectBranch()");
-      return this.put("projects/" + (Utils.parseProjectId(projectId)) + "/repository/branches/" + (encodeURI(branchId)) + "/protect", null, (function(_this) {
+      return this.put("projects/" + (Utils.parseProjectId(projectId)) + "/repository/branches/" + (encodeURI(branchId)) + "/protect", params, (function(_this) {
         return function(data) {
           if (fn) {
             return fn(data);

--- a/src/Models/ProjectMergeRequests.coffee
+++ b/src/Models/ProjectMergeRequests.coffee
@@ -43,4 +43,13 @@ class ProjectMergeRequests extends BaseModel
       note:             note
     @post "projects/#{Utils.parseProjectId projectId}/merge_request/#{parseInt mergerequestId}/comments", params, (data) => fn data if fn
 
+  merge: (projectId, mergerequestId, params, fn = null) =>
+    @debug "Projects::acceptMergeRequest()"
+
+    params.id = Utils.parseProjectId projectId
+    params.merge_request_id = parseInt mergerequestId
+
+    @put "projects/#{Utils.parseProjectId projectId}/merge_request/#{parseInt mergerequestId}/merge", params, (data) => fn data if fn
+
+
 module.exports = (client) -> new ProjectMergeRequests client

--- a/src/Models/ProjectRepository.coffee
+++ b/src/Models/ProjectRepository.coffee
@@ -12,9 +12,9 @@ class ProjectRepository extends BaseModel
     @debug "Projects::branch()"
     @get "projects/#{Utils.parseProjectId projectId}/repository/branches/#{encodeURI branchId}", (data) => fn data if fn
 
-  protectBranch: (projectId, branchId, fn = null) =>
+  protectBranch: (projectId, branchId, params = {}, fn = null) =>
     @debug "Projects::protectBranch()"
-    @put "projects/#{Utils.parseProjectId projectId}/repository/branches/#{encodeURI branchId}/protect", null, (data) => fn data if fn
+    @put "projects/#{Utils.parseProjectId projectId}/repository/branches/#{encodeURI branchId}/protect", params, (data) => fn data if fn
 
   unprotectBranch: (projectId, branchId, fn = null) =>
     @debug "Projects::unprotectBranch()"


### PR DESCRIPTION
This pull request introduces three changes (probably should have made 3 pull requests, will happen next time):

- README.md: changed the API link as it was pointing to v4 and this module supports v3;
- ProjectMergeRequests.js/ProjectMergeRequests.coffee : new function `merge` to accept merge requests;
- ProjectRepository.js/ProjectRepository.coffee : function `protectBranch` is now accepting parameters for PUT request body.