### PR TITLE
README: Update default value of version parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Available instantiating options:
 | `jobToken`           | No\*     | N/A                                                   | CI Job Token. Required (one of the three tokens are required)                                                      |
 | `rejectUnauthorized` | Yes      | `false`                                               | Http Certificate setting                                                                                           |
 | `sudo`               | Yes      | `false`                                               | [Sudo](https://docs.gitlab.com/ee/api/#sudo) query parameter                                                       |
-| `version`            | Yes      | `v4`                                                  | API Version ID                                                                                                     |
+| `version`            | Yes      | `4`                                                  | API Version ID                                                                                                     |
 | `camelize`           | Yes      | `false`                                               | Camelizes all response body keys                                                                                   |
 | `requester`          | Yes      | [KyRequester.ts](./src/infrastructure/KyRequester.ts) | Request Library Wrapper. Currently wraps Ky.                                                                       |
 | `requestTimeout`     | Yes      | `300000`                                              | Request Library Timeout in ms                                                                                      |


### PR DESCRIPTION
The default for `version` was changed in 6558f09522ccb27d4314d99394086301fe5ae85e and is now a number not a string. The `README` still uses the old default value (`v4`) instead of the new value (`4`).

Thanks so much for this package (our CI/CD heavily depends on it!) and let me know if you want me to make any changes to this PR.