### PR TITLE
fix: Typing on GPGKey method arguments was missing

### DIFF
--- a/src/core/services/UserGPGKeys.ts
+++ b/src/core/services/UserGPGKeys.ts
@@ -12,21 +12,20 @@ export class UserGPGKeys extends BaseService {
     return RequestHelper.get(this, url(userId), options);
   }
 
-  add(title, key, { userId, ...options }: { userId?: number } & BaseRequestOptions = {}) {
+  add(key: string, { userId, ...options }: { userId?: number } & BaseRequestOptions = {}) {
     return RequestHelper.post(this, url(userId), {
-      title,
       key,
       ...options,
     });
   }
 
-  show(keyId, { userId, ...options }: { userId?: number } & BaseRequestOptions = {}) {
+  show(keyId: number, { userId, ...options }: { userId?: number } & BaseRequestOptions = {}) {
     const kId = encodeURIComponent(keyId);
 
     return RequestHelper.get(this, `${url(userId)}/${kId}`, options);
   }
 
-  remove(keyId, { userId, ...options }: { userId?: number } & BaseRequestOptions = {}) {
+  remove(keyId: number, { userId, ...options }: { userId?: number } & BaseRequestOptions = {}) {
     const kId = encodeURIComponent(keyId);
 
     return RequestHelper.del(this, `${url(userId)}/${kId}`, options);


### PR DESCRIPTION
BREAKING CHANGE: The title property is not required for the [add]( https://docs.gitlab.com/ee/api/users.html#add-a-gpg-key) method.